### PR TITLE
ARM64 Compatibility

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,13 +11,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-    
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
             username: ${{ secrets.REGISTRY_USERNAME }}
             password: ${{ secrets.REGISTRY_PASSWORD }}
-          
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -32,6 +38,9 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ####  SERVER
 ############################################################################################
 
-# Using the `rust-musl-builder` as base image, instead of 
+# Using the `rust-musl-builder` as base image, instead of
 # the official Rust toolchain
 FROM clux/muslrust:stable AS chef
 USER root
@@ -13,13 +13,34 @@ FROM chef AS planner
 COPY ./pentaract .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM chef AS builder 
+FROM chef AS builder
+
+# BuildKit provides TARGETARCH automatically (amd64 or arm64)
+ARG TARGETARCH
+
+# Map Docker's architecture names to Rust target triples
+RUN case "${TARGETARCH}" in \
+        "amd64") echo "x86_64-unknown-linux-musl" > /tmp/rust_target ;; \
+        "arm64") echo "aarch64-unknown-linux-musl" > /tmp/rust_target ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac
+
+# Add ARM64 target if needed
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+        rustup target add aarch64-unknown-linux-musl; \
+    fi
+
 COPY --from=planner /app/recipe.json recipe.json
+
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
+RUN cargo chef cook --release --target $(cat /tmp/rust_target) --recipe-path recipe.json
+
 # Build application
 COPY ./pentaract .
-RUN cargo build --target x86_64-unknown-linux-musl --release
+RUN cargo build --target $(cat /tmp/rust_target) --release
+
+# Move binary to a known location regardless of architecture
+RUN cp /app/target/$(cat /tmp/rust_target)/release/pentaract /app/pentaract-binary
 
 ############################################################################################
 ####  UI
@@ -39,7 +60,7 @@ RUN pnpm run build
 
 # We do not need the Rust toolchain to run the binary!
 FROM scratch AS runtime
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/pentaract /
+COPY --from=builder /app/pentaract-binary /pentaract
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=ui /app/dist /ui
 ENTRYPOINT ["/pentaract"]

--- a/pentaract/Cargo.toml
+++ b/pentaract/Cargo.toml
@@ -34,4 +34,4 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"]}
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid"] }
 thiserror = "1.0.50"
 uuid = { version = "1.5.0", features = ["serde", "v4"] }
-reqwest = { version = "0.11.22", features = ["multipart", "json"] }
+reqwest = { version = "0.11.22", default-features = false, features = ["multipart", "json", "rustls-tls"] }


### PR DESCRIPTION
  Enable ARM64 Build Support

  Summary

  This PR adds multi-architecture Docker image support, enabling builds for both linux/amd64 and linux/arm64 platforms.

  Changes

  GitHub Actions Workflow (.github/workflows/docker-image.yml)
  - Added QEMU setup for cross-platform emulation
  - Added Docker Buildx for multi-platform builds
  - Enabled linux/amd64,linux/arm64 platform targets
  - Added GitHub Actions cache for faster builds

  Dockerfile
  - Implemented dynamic architecture detection using TARGETARCH build argument
  - Added conditional Rust target selection (x86_64 vs aarch64)
  - Modified build commands to use architecture-specific targets
  - Unified binary output path for consistent runtime stage

  Dependencies (pentaract/Cargo.toml)
  - Replaced OpenSSL with rustls-tls in reqwest to avoid cross-compilation issues with native OpenSSL libraries

  Why

  ARM64 support enables running Pentaract on Apple Silicon Macs, AWS Graviton instances, and other ARM-based infrastructure, improving deployment flexibility and reducing costs on ARM
  platforms.